### PR TITLE
small fixes to make it work

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -11,5 +11,5 @@ if __name__ == "__main__":
             "Couldn't import Django. Are you sure it's installed and "
             "available on your PYTHONPATH environment variable? Did you "
             "forget to activate a virtual environment?"
-        ) from exc
+        )
     execute_from_command_line(sys.argv)

--- a/readme.rst
+++ b/readme.rst
@@ -1,0 +1,20 @@
+Scipion Workflows
+=================
+
+Install
+-------
+
+To install this software, clone this repository and run::
+
+  $ virtualenv --python /usr/bin/python3 .env
+  $ . .env/bin/activate
+  $ pip install -r requirements.txt
+  $ python manage.py migrate
+
+
+Running
+-------
+
+  $ python manage.py runserver
+
+It will open a webserver listening at port 8000.

--- a/readme.rst
+++ b/readme.rst
@@ -15,6 +15,8 @@ To install this software, clone this repository and run::
 Running
 -------
 
+::
+
   $ python manage.py runserver
 
 It will open a webserver listening at port 8000.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+Django==2.0.3
 loremipsum==1.0.5
 Pillow==5.0.0
 pytz==2018.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-Django==2.0.3
 loremipsum==1.0.5
 Pillow==5.0.0
 pytz==2018.3

--- a/scipionWorkflowRepository/settings.py
+++ b/scipionWorkflowRepository/settings.py
@@ -29,7 +29,7 @@ SECRET_KEY = '19j8)(*pq=60@u-fg==*wl0#*2g^7882!&8xy@&pe@*%1cfy)w'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['workflows.scipion.i2pc.es']
 
 
 # Application definition
@@ -127,4 +127,3 @@ STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'static'),
 )
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticHeroku')
-


### PR DESCRIPTION
Just fixing a typo in manage.py that stopped it from running, added its expected address (workflows.scipion.i2pc.es) to the `ALLOWED_HOSTS` so it would actually run remotely, and a bit of documentation.